### PR TITLE
Extract a palette from the first input image: `--palette "sample"`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.16
 require (
 	github.com/disintegration/imaging v1.6.2
 	github.com/makeworld-the-better-one/dither/v2 v2.3.0
+	github.com/mccutchen/palettor v1.0.0 // indirect
 	github.com/urfave/cli/v2 v2.3.0
 	golang.org/x/image v0.0.0-20210220032944-ac19c3e999fb
 )

--- a/go.sum
+++ b/go.sum
@@ -7,6 +7,9 @@ github.com/disintegration/imaging v1.6.2 h1:w1LecBlG2Lnp8B3jk5zSuNqd7b4DXhcjwek1
 github.com/disintegration/imaging v1.6.2/go.mod h1:44/5580QXChDfwIclfc/PCwrr44amcmDAg8hxG0Ewe4=
 github.com/makeworld-the-better-one/dither/v2 v2.3.0 h1:s9wgm88KFZSzvZh9gL79tPayp5sDUGIku/1aJewxlB4=
 github.com/makeworld-the-better-one/dither/v2 v2.3.0/go.mod h1:VBtN8DXO7SNtyGmLiGA7IsFeKrBkQPze1/iAeM95arc=
+github.com/mccutchen/palettor v1.0.0 h1:YRNAzEZlRBnu8qP/9siuNTJiAj7VhL0dEQ1AQmu9jew=
+github.com/mccutchen/palettor v1.0.0/go.mod h1:5ZFq9YwI0o5zRpmAuEsm+0B7divaVds1dvTAznEnd6g=
+github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646/go.mod h1:jpp1/29i3P1S/RLdc7JQKbRpFeM1dOBd8T9ki5s+AY8=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/russross/blackfriday/v2 v2.0.1 h1:lPqVAte+HuHNfhJ/0LC98ESWRz8afy9tM/0RK8m9o+Q=

--- a/subcommands.go
+++ b/subcommands.go
@@ -71,39 +71,6 @@ func preProcess(c *cli.Context) error {
 	runtime.GOMAXPROCS(int(c.Uint("threads")))
 
 	var err error
-	palette, err = parseColors("palette", c)
-	if err != nil {
-		return err
-	}
-	if len(palette) < 2 {
-		return errors.New("the palette must have at least two colors")
-	}
-
-	if c.String("recolor") != "" {
-		recolorPalette, err = parseColors("recolor", c)
-		if err != nil {
-			return err
-		}
-		if len(recolorPalette) != len(palette) {
-			return errors.New("recolor palette must have the same number of colors as the initial palette")
-		}
-	}
-
-	// Check if palette is grayscale and make image grayscale
-	// Or if the user forces it
-
-	grayscale = true
-	if !c.Bool("grayscale") {
-		// Grayscale isn't specified by the user
-		// So check to see if palette is grayscale
-		for _, c := range palette {
-			r, g, b, _ := c.RGBA()
-			if r != g || g != b {
-				grayscale = false
-				break
-			}
-		}
-	}
 
 	saturation, err = parsePercentArg(c.String("saturation"), false)
 	if err != nil {
@@ -135,6 +102,40 @@ func preProcess(c *cli.Context) error {
 			inputImages = append(inputImages, paths...)
 		} else {
 			inputImages = append(inputImages, path)
+		}
+	}
+
+	palette, err = parseColors("palette", c)
+	if err != nil {
+		return err
+	}
+	if len(palette) < 2 {
+		return errors.New("the palette must have at least two colors")
+	}
+
+	if c.String("recolor") != "" {
+		recolorPalette, err = parseColors("recolor", c)
+		if err != nil {
+			return err
+		}
+		if len(recolorPalette) != len(palette) {
+			return errors.New("recolor palette must have the same number of colors as the initial palette")
+		}
+	}
+
+	// Check if palette is grayscale and make image grayscale
+	// Or if the user forces it
+
+	grayscale = true
+	if !c.Bool("grayscale") {
+		// Grayscale isn't specified by the user
+		// So check to see if palette is grayscale
+		for _, c := range palette {
+			r, g, b, _ := c.RGBA()
+			if r != g || g != b {
+				grayscale = false
+				break
+			}
 		}
 	}
 


### PR DESCRIPTION
## Changes

Adds a dependency on https://github.com/mccutchen/palettor.

When passed `--palette "sample"`, use `palettor` to extract a $k$-palette from the 0th input image.

Shuffles `preProcess` order: parse the `inputImages` before 

### Things to check

+ Docs need updating.
  + Document the `--palette "sample"` behavior.
  + Document the parameterized palette size $k$.
+ Does this behave reasonably for multiple input images?
+ Does this behave reasonably when the image comes from stdin?

## Testing
