### PR TITLE
ci: replace --rm-dist with --clean

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -21,6 +21,6 @@ jobs:
         uses: goreleaser/goreleaser-action@v2
         with:
           version: v1.22.1
-          args: release --rm-dist
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
--rm-dist was deprecated.

https://github.com/suzuki-shunsuke/didder/actions/runs/7281779148/job/19842954753#step:4:21

```
  • DEPRECATED: --rm-dist was deprecated in favor of --clean, check https://goreleaser.com/deprecations#-rm-dist for more details
```

https://goreleaser.com/deprecations#-rm-dist