### PR TITLE
GitHub actions: fix warning: restore cache failed

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -17,6 +17,8 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: 1.21
+          cache: true
+          cache-dependency-path: '**/go.sum'
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v5
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,6 +24,8 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go-version }}
+          cache: true
+          cache-dependency-path: '**/go.sum'
       - name: Checkout code
         uses: actions/checkout@v4
       - uses: actions/cache@v4


### PR DESCRIPTION
This PR fixes the warnings seen [here](https://github.com/makew0rld/didder/actions/runs/8317203569):

```
Restore cache failed: Dependencies file is not found in /home/runner/work/didder/didder. Supported file pattern: go.sum
```
